### PR TITLE
add init to Date:  millisecondsSince1970

### DIFF
--- a/Sources/Date.swift
+++ b/Sources/Date.swift
@@ -63,6 +63,12 @@ public struct Date: ByteValue, Equatable, Comparable, CustomStringConvertible, F
         
         timeIntervalSinceReferenceDate = timeInterval - TimeIntervalBetween1970AndReferenceDate
     }
+    
+    /// Creates the date with the specified number of milliseconds since 1 January 1970, GMT. Similar to Javascript.
+    public init(millisecondsSince1970 ms: Long) {
+        
+        timeIntervalSinceReferenceDate = ms/1000 - TimeIntervalBetween1970AndReferenceDate
+    }
 }
 
 // MARK: - Operator Overloading


### PR DESCRIPTION
This convenience initializer take milliseconds as Long instead of a Double value of seconds. This is similar to the Date class in Javascript, and is useful for many JSON APIs that use number of milliseconds since epoch to represent dates.

Further I think the word TimeInterval should be renamed to Seconds in the API of the Date object to be less vague.
