### PR TITLE
make file manager set function truncate opened file at first

### DIFF
--- a/Sources/SwiftFoundation/FileManager.swift
+++ b/Sources/SwiftFoundation/FileManager.swift
@@ -212,7 +212,7 @@ public struct FileManager {
     public static func set(contents data: Data, at path: String) throws {
         
         // get file descriptor for path (open file)
-        let file = open(path, O_WRONLY)
+        let file = open(path, O_TRUNC | O_WRONLY)
         
         guard file != -1 else { throw POSIXError.fromErrno! }
         


### PR DESCRIPTION
Without truncate opened file at first , the result of file manager set function did not meet expectation
